### PR TITLE
Интеграция с Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ telegram.bot.username=@your_bot
 ./gradlew bootJar
 ```
 
+## Kafka через Docker
+
+Для работы Kafka в режиме разработки используйте `docker-compose.yml`:
+
+```bash
+docker-compose up -d
+```
+
+Он запустит Zookeeper и Kafka на стандартных портах `2181` и `9092`.
+
+
 ## Настройка webhook
 
 После деплоя приложения по HTTPS зарегистрируйте webhook в Telegram:

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.telegram:telegrambots:6.5.0'
     implementation 'org.springframework:spring-context:6.1.4'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+

--- a/src/main/java/org/example/autobot/TelegramVacancyBot.java
+++ b/src/main/java/org/example/autobot/TelegramVacancyBot.java
@@ -1,6 +1,7 @@
 package org.example.autobot;
 
 import org.example.autobot.command.CommandHandler;
+import org.example.autobot.kafka.KafkaUpdateProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ public class TelegramVacancyBot extends TelegramLongPollingBot {
     private static final Logger log = LoggerFactory.getLogger(TelegramVacancyBot.class);
 
     private final CommandHandler commandHandler;
+    private final KafkaUpdateProducer updateProducer;
 
     @Value("${telegram.bot.token}")
     private String token;
@@ -21,13 +23,15 @@ public class TelegramVacancyBot extends TelegramLongPollingBot {
     @Value("${telegram.bot.username}")
     private String username;
 
-    public TelegramVacancyBot(CommandHandler commandHandler) {
+    public TelegramVacancyBot(CommandHandler commandHandler, KafkaUpdateProducer updateProducer) {
         this.commandHandler = commandHandler;
+        this.updateProducer = updateProducer;
     }
 
     @Override
     public void onUpdateReceived(Update update) {
         log.info("📥 Update received: {}", update);
+        updateProducer.send(update);
         commandHandler.handle(update);
     }
 

--- a/src/main/java/org/example/autobot/kafka/KafkaCommandConsumer.java
+++ b/src/main/java/org/example/autobot/kafka/KafkaCommandConsumer.java
@@ -1,0 +1,21 @@
+package org.example.autobot.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaCommandConsumer {
+    private static final Logger log = LoggerFactory.getLogger(KafkaCommandConsumer.class);
+
+    @Value("${telegram.commands.topic:telegram-commands}")
+    private String topic;
+
+    @KafkaListener(topics = "#{'${telegram.commands.topic:telegram-commands}'}", groupId = "${spring.kafka.consumer.group-id}")
+    public void listen(String message) {
+        log.info("Received command from topic {}: {}", topic, message);
+        // Здесь можно добавить обработку входящих команд
+    }
+}

--- a/src/main/java/org/example/autobot/kafka/KafkaUpdateProducer.java
+++ b/src/main/java/org/example/autobot/kafka/KafkaUpdateProducer.java
@@ -1,0 +1,34 @@
+package org.example.autobot.kafka;
+
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+@Service
+public class KafkaUpdateProducer {
+    private static final Logger log = LoggerFactory.getLogger(KafkaUpdateProducer.class);
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final Gson gson = new Gson();
+
+    @Value("${telegram.update.topic:telegram-updates}")
+    private String topic;
+
+    public KafkaUpdateProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void send(Update update) {
+        try {
+            String json = gson.toJson(update);
+            kafkaTemplate.send(topic, json);
+            log.debug("Sent update to Kafka topic {}", topic);
+        } catch (Exception e) {
+            log.error("Failed to send update to Kafka", e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,15 @@
 telegram.bot.token=1885942942:AAGzEmy7tdiA8fl-YxwaU_PEIPk3rbMSHK0
 telegram.bot.username=@clever8_bot
+
+# Kafka configuration
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.consumer.group-id=telegram-bot
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# Topics
+telegram.update.topic=telegram-updates
+telegram.commands.topic=telegram-commands


### PR DESCRIPTION
## Summary
- add spring-kafka dependency
- configure Kafka topics and client properties in `application.properties`
- send every incoming `Update` to Kafka from `TelegramVacancyBot`
- add optional Kafka command consumer
- provide docker-compose for Kafka/Zookeeper
- document how to run Kafka in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68533ab2e588832d9a3c656499b081b1