### PR TITLE
Fix env var reading without dotenv plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testImplementation 'com.h2database:h2'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 java {

--- a/src/main/java/org/example/autobot/AutobotApplication.java
+++ b/src/main/java/org/example/autobot/AutobotApplication.java
@@ -2,9 +2,11 @@ package org.example.autobot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 @EnableAsync
 public class AutobotApplication {
     public static void main(String[] args) {

--- a/src/main/java/org/example/autobot/TelegramVacancyBot.java
+++ b/src/main/java/org/example/autobot/TelegramVacancyBot.java
@@ -5,7 +5,7 @@ import org.example.autobot.kafka.KafkaUpdateProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.example.autobot.config.TelegramBotProperties;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -17,20 +17,17 @@ public class TelegramVacancyBot extends TelegramLongPollingBot {
 
     private final CommandHandler commandHandler;
     private final KafkaUpdateProducer updateProducer;  // может быть null
-
-    @Value("${telegram.bot.token}")
-    private String token;
-
-    @Value("${telegram.bot.username}")
-    private String username;
+    private final TelegramBotProperties properties;
 
     // Внедряем KafkaUpdateProducer с required=false
     public TelegramVacancyBot(
             CommandHandler commandHandler,
-            @Autowired(required = false) KafkaUpdateProducer updateProducer
+            @Autowired(required = false) KafkaUpdateProducer updateProducer,
+            TelegramBotProperties properties
     ) {
         this.commandHandler = commandHandler;
         this.updateProducer = updateProducer;
+        this.properties = properties;
     }
 
     @Override
@@ -48,12 +45,12 @@ public class TelegramVacancyBot extends TelegramLongPollingBot {
 
     @Override
     public String getBotUsername() {
-        return username;
+        return properties.getUsername();
     }
 
     @Override
     public String getBotToken() {
-        return token;
+        return properties.getToken();
     }
 
     // Если используется, можно оставить

--- a/src/main/java/org/example/autobot/config/HhOAuthProperties.java
+++ b/src/main/java/org/example/autobot/config/HhOAuthProperties.java
@@ -1,0 +1,34 @@
+package org.example.autobot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "hh.oauth")
+public class HhOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+}

--- a/src/main/java/org/example/autobot/config/TelegramBotProperties.java
+++ b/src/main/java/org/example/autobot/config/TelegramBotProperties.java
@@ -1,0 +1,25 @@
+package org.example.autobot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "telegram.bot")
+public class TelegramBotProperties {
+    private String token;
+    private String username;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/src/test/java/org/example/autobot/service/HhAuthServiceTest.java
+++ b/src/test/java/org/example/autobot/service/HhAuthServiceTest.java
@@ -7,7 +7,6 @@ import org.example.autobot.repository.HhProfileRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
@@ -33,11 +32,11 @@ class HhAuthServiceTest {
         // Внедряем WebClient с базовым URL mock-сервера
         WebClient.Builder builder = WebClient.builder()
                 .baseUrl(server.url("/").toString());
-        service = new HhAuthService(repo, builder, server.url("/").toString());
-        // Устанавливаем приватные поля через рефлексию
-        ReflectionTestUtils.setField(service, "clientId", "testId");
-        ReflectionTestUtils.setField(service, "clientSecret", "testSecret");
-        ReflectionTestUtils.setField(service, "redirectUri", "http://localhost/callback");
+        var props = new org.example.autobot.config.HhOAuthProperties();
+        props.setClientId("testId");
+        props.setClientSecret("testSecret");
+        props.setRedirectUri("http://localhost/callback");
+        service = new HhAuthService(repo, builder, props, server.url("/").toString());
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary
- manage HH OAuth and Telegram bot settings via `@ConfigurationProperties`
- enable property scanning in `AutobotApplication`
- update tests for new constructor
- generate configuration metadata with spring-boot-configuration-processor

## Testing
- `./gradlew clean test --no-daemon`
- `./gradlew bootRun --no-daemon` *(fails: Unable to determine Dialect without JDBC metadata)*

------
https://chatgpt.com/codex/tasks/task_e_6863f947e434832d8bc9b411a84ba19c