### PR TITLE
Add FastAPI OAuth integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+HH_CLIENT_ID=your_client_id
+HH_CLIENT_SECRET=your_client_secret
+HH_REDIRECT_URI=http://localhost:8000/callback
+DATABASE_URL=sqlite+aiosqlite:///./app.db

--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ curl -X POST https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getWebhookInfo
 ```
 
 Повторный запуск скрипта перезапишет предыдущий адрес webhook для того же токена.
+
+## OAuth FastAPI
+
+В проекте есть отдельный сервис на Python для привязки профиля HeadHunter.
+
+Инструкция по запуску находится в каталоге `hh_oauth_fastapi/README.md`.

--- a/hh_oauth_fastapi/README.md
+++ b/hh_oauth_fastapi/README.md
@@ -1,0 +1,23 @@
+# HH OAuth FastAPI Service
+
+Сервис выполняет привязку профиля HeadHunter через OAuth и сохраняет токены в БД.
+
+## Запуск
+
+1. Установите зависимости:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Создайте файл `.env` на основе `.env.example` и заполните значения.
+
+3. База данных создаётся автоматически при запуске приложения.
+
+4. Запустите сервер:
+
+```bash
+uvicorn hh_oauth_fastapi.main:app --reload
+```
+
+Endpoint для редиректа: `/callback`.

--- a/hh_oauth_fastapi/database.py
+++ b/hh_oauth_fastapi/database.py
@@ -1,0 +1,17 @@
+import os
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker, declarative_base
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+
+engine = create_async_engine(DATABASE_URL, future=True, echo=False)
+AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+Base = declarative_base()
+
+async def init_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/hh_oauth_fastapi/main.py
+++ b/hh_oauth_fastapi/main.py
@@ -1,0 +1,64 @@
+import os
+import logging
+
+from fastapi import FastAPI, Query, HTTPException
+from fastapi.responses import JSONResponse
+import httpx
+from dotenv import load_dotenv
+
+from .database import AsyncSessionLocal, init_db
+from .models import Profile
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+HH_CLIENT_ID = os.getenv("HH_CLIENT_ID")
+HH_CLIENT_SECRET = os.getenv("HH_CLIENT_SECRET")
+HH_REDIRECT_URI = os.getenv("HH_REDIRECT_URI")
+
+app = FastAPI()
+
+@app.on_event("startup")
+async def on_startup():
+    await init_db()
+
+@app.get("/callback")
+async def callback(code: str = Query(...), state: int = Query(...)):
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://hh.ru/oauth/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "client_id": HH_CLIENT_ID,
+                    "client_secret": HH_CLIENT_SECRET,
+                    "code": code,
+                    "redirect_uri": HH_REDIRECT_URI,
+                },
+            )
+        resp.raise_for_status()
+        data = resp.json()
+        access_token = data["access_token"]
+        refresh_token = data["refresh_token"]
+
+        async with AsyncSessionLocal() as session:
+            profile = Profile(
+                chat_id=state,
+                access_token=access_token,
+                refresh_token=refresh_token,
+            )
+            session.add(profile)
+            await session.commit()
+
+        return JSONResponse({"status": "ok", "msg": "Профиль успешно привязан"})
+    except Exception as e:
+        logger.error(
+            "Ошибка при обмене code→token для chat_id=%s: %s", state, e
+        )
+        raise HTTPException(
+            status_code=500,
+            detail={"status": "error", "msg": "Ошибка привязки профиля"},
+        )
+__all__ = ["app", "init_db", "AsyncSessionLocal", "Profile"]

--- a/hh_oauth_fastapi/models.py
+++ b/hh_oauth_fastapi/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, BigInteger, Text
+from .database import Base
+
+class Profile(Base):
+    __tablename__ = 'profiles'
+
+    chat_id = Column(BigInteger, primary_key=True)
+    access_token = Column(Text, nullable=False)
+    refresh_token = Column(Text, nullable=False)

--- a/hh_oauth_fastapi/tests/test_callback.py
+++ b/hh_oauth_fastapi/tests/test_callback.py
@@ -1,0 +1,50 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import os
+import pytest
+import respx
+from httpx import Response
+import pytest_asyncio
+from fastapi import status
+from httpx import AsyncClient
+from httpx import ASGITransport
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("HH_CLIENT_ID", "client")
+os.environ.setdefault("HH_CLIENT_SECRET", "secret")
+os.environ.setdefault("HH_REDIRECT_URI", "http://test")
+
+from hh_oauth_fastapi.main import app, init_db, AsyncSessionLocal, Profile
+from sqlalchemy import select
+
+@pytest_asyncio.fixture(autouse=True, scope="module")
+async def setup_db():
+    await init_db()
+    yield
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_callback_success():
+    respx.post("https://hh.ru/oauth/token").mock(
+        return_value=Response(200, json={"access_token": "a", "refresh_token": "r"})
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/callback", params={"code": "123", "state": 1})
+    assert response.status_code == status.HTTP_200_OK
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(Profile))
+        profiles = result.scalars().all()
+        assert len(profiles) == 1
+        assert profiles[0].chat_id == 1
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_callback_failure():
+    respx.post("https://hh.ru/oauth/token").mock(return_value=Response(400))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        response = await ac.get("/callback", params={"code": "bad", "state": 2})
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(select(Profile).where(Profile.chat_id == 2))
+        profile = result.scalar()
+        assert profile is None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+httpx
+python-dotenv
+sqlalchemy>=1.4
+asyncpg
+aiosqlite
+pytest
+pytest-asyncio
+respx


### PR DESCRIPTION
## Summary
- add FastAPI service to handle hh.ru OAuth
- store tokens in SQLite or PostgreSQL via SQLAlchemy
- provide unit tests using respx and pytest
- update docs and include example `.env`

## Testing
- `pytest -q hh_oauth_fastapi/tests/test_callback.py`

------
https://chatgpt.com/codex/tasks/task_e_6865accb43c0832d98981c21cca0bda1