### PR TITLE
Добавить inline-кнопки для фильтрации вакансий

### DIFF
--- a/hhbot/bot.py
+++ b/hhbot/bot.py
@@ -1,20 +1,35 @@
 """Telegram bot handlers."""
 
 import logging
-from telegram import Update
-from telegram.ext import Application, ApplicationBuilder, CommandHandler, ContextTypes
+import asyncio
+from typing import Dict
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import (
+    Updater,
+    CommandHandler,
+    CallbackContext,
+    CallbackQueryHandler,
+    MessageHandler,
+    Filters,
+)
 
 from .config import settings
 from .auth import build_auth_url
-from .vacancies import fetch_and_format_vacancies
+from .vacancies import (
+    filter_by_keywords,
+    filter_by_city,
+    filter_by_salary,
+)
 from .resume import fetch_resume
 
 logger = logging.getLogger(__name__)
 
+# Состояние ожидания ввода для каждого пользователя
+user_states: Dict[int, str] = {}
 
-async def start(
-    update: Update, context: ContextTypes.DEFAULT_TYPE
-) -> None:
+
+def start(update: Update, context: CallbackContext) -> None:
+    """Команда /start и /help."""
     text = (
         "\U0001F44B Привет! Я бот для автоматизации откликов на hh.ru.\n"
         "• /vacancies — поиск свежих вакансий\n"
@@ -22,39 +37,114 @@ async def start(
         "• /resume — получить ваше резюме\n"
         "• /help — список команд"
     )
-    await update.message.reply_text(text)
+    update.message.reply_text(text)
 
 
 help_cmd = start  # alias
 
 
-async def auth(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+def auth(update: Update, context: CallbackContext) -> None:
+    """Отправить ссылку для авторизации на hh.ru."""
     url = build_auth_url(update.effective_chat.id)
-    await update.message.reply_text(
+    update.message.reply_text(
         f"\U0001F517 Перейдите по ссылке и авторизуйтесь:\n{url}"
     )
 
 
-async def vacancies(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    text = await fetch_and_format_vacancies()
-    await update.message.reply_markdown(text)
+def vacancies(update: Update, context: CallbackContext) -> None:
+    """Показать кнопки для выбора фильтра вакансий."""
+    keyboard = [
+        [InlineKeyboardButton("По ключевым словам", callback_data="keyword")],
+        [InlineKeyboardButton("По городу", callback_data="city")],
+        [InlineKeyboardButton("По зарплате", callback_data="salary")],
+    ]
+    update.message.reply_text(
+        "Выберите способ фильтрации вакансий:",
+        reply_markup=InlineKeyboardMarkup(keyboard),
+    )
 
 
-async def resume(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+def _on_filter_choice(update: Update, context: CallbackContext) -> None:
+    """Обработка нажатия на inline-кнопки."""
+    query = update.callback_query
+    query.answer()
+    chat_id = query.message.chat_id
+    if query.data == "keyword":
+        user_states[chat_id] = "keyword"
+        query.message.reply_text("Введите ключевые слова для поиска вакансий:")
+    elif query.data == "city":
+        user_states[chat_id] = "city"
+        query.message.reply_text("Введите город для поиска:")
+    elif query.data == "salary":
+        user_states[chat_id] = "salary"
+        query.message.reply_text("Введите минимальную зарплату в рублях:")
+
+
+def _on_text(update: Update, context: CallbackContext) -> None:
+    """Обработка текстового ответа пользователя после выбора фильтра."""
+    chat_id = update.effective_chat.id
+    state = user_states.get(chat_id)
+    if not state:
+        return
+
+    text = update.message.text.strip()
+    if state == "keyword":
+        items = filter_by_keywords(text)
+    elif state == "city":
+        items = filter_by_city(text)
+    elif state == "salary":
+        try:
+            value = int(text)
+        except ValueError:
+            update.message.reply_text("Введите число.")
+            return
+        items = filter_by_salary(value)
+    else:
+        items = []
+
+    user_states.pop(chat_id, None)
+
+    if not items:
+        update.message.reply_text("Не найдено подходящих вакансий.")
+        return
+
+    lines = [f"{vac['title']}\n{vac['url']}" for vac in items[:5]]
+    update.message.reply_text(
+        "\n\n".join(lines), disable_web_page_preview=True
+    )
+
+
+def resume(update: Update, context: CallbackContext) -> None:
+    """Получить резюме пользователя."""
     try:
-        text = await fetch_resume(update.effective_chat.id)
-        await update.message.reply_text(text)
+        text = asyncio.run(fetch_resume(update.effective_chat.id))
+        update.message.reply_text(text)
     except Exception:
-        await update.message.reply_text(
+        update.message.reply_text(
             "\u274C Не могу получить резюме. Сначала выполните /auth"
         )
 
 
-def build_bot() -> Application:
-    app = ApplicationBuilder().token(settings.telegram_bot_token).build()
-    app.add_handler(CommandHandler("start", start))
-    app.add_handler(CommandHandler("help", help_cmd))
-    app.add_handler(CommandHandler("auth", auth))
-    app.add_handler(CommandHandler("vacancies", vacancies))
-    app.add_handler(CommandHandler("resume", resume))
-    return app
+class BotApp:
+    """Обёртка над Updater с методом run_polling для совместимости."""
+
+    def __init__(self, updater: Updater):
+        self.updater = updater
+
+    def run_polling(self) -> None:
+        self.updater.start_polling()
+        self.updater.idle()
+
+
+def build_bot() -> BotApp:
+    """Создать экземпляр бота."""
+    updater = Updater(token=settings.telegram_bot_token, use_context=True)
+    dp = updater.dispatcher
+    dp.add_handler(CommandHandler("start", start))
+    dp.add_handler(CommandHandler("help", help_cmd))
+    dp.add_handler(CommandHandler("auth", auth))
+    dp.add_handler(CommandHandler("vacancies", vacancies))
+    dp.add_handler(CommandHandler("resume", resume))
+    dp.add_handler(CallbackQueryHandler(_on_filter_choice))
+    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, _on_text))
+    return BotApp(updater)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 requests
-python-telegram-bot==20.7
+python-telegram-bot==13.15
 python-dotenv
 pydantic
 pytest

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,8 +10,122 @@ os.environ.setdefault("HH_CLIENT_SECRET", "s")
 os.environ.setdefault("HH_REDIRECT_URI", "http://test")
 
 from hhbot.auth import build_auth_url
+from hhbot.vacancies import (
+    filter_by_keywords,
+    filter_by_city,
+    filter_by_salary,
+    raw_vacancies,
+)
+from hhbot.bot import user_states, _on_filter_choice, _on_text
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def sample_vacancies():
+    raw_vacancies[:] = [
+        {
+            "name": "Python разработчик",
+            "alternate_url": "http://e/1",
+            "area": {"name": "Москва"},
+            "salary": {"from": 150000, "currency": "RUR"},
+        },
+        {
+            "name": "Java developer",
+            "alternate_url": "http://e/2",
+            "area": {"name": "Санкт-Петербург"},
+            "salary": {"to": 120000, "currency": "RUR"},
+        },
+        {
+            "name": "Data Scientist",
+            "alternate_url": "http://e/3",
+            "area": {"name": "Москва"},
+            "salary": {"from": 200000, "currency": "RUR"},
+        },
+        {
+            "name": "Python QA engineer",
+            "alternate_url": "http://e/4",
+            "area": {"name": "Новосибирск"},
+            "salary": None,
+        },
+        {
+            "name": "Python разработчик",
+            "alternate_url": "http://e/5",
+            "area": {"name": "Москва"},
+            "salary": {"from": 100000, "currency": "RUR"},
+        },
+    ]
+    yield
+    raw_vacancies.clear()
 
 
 def test_build_auth_url():
     url = build_auth_url(123)
     assert "state=123" in url
+
+
+def test_filter_by_keywords(sample_vacancies):
+    res = filter_by_keywords("Python разработчик")
+    assert len(res) == 2
+    assert all("Python" in r["title"] for r in res)
+
+
+def test_filter_by_city(sample_vacancies):
+    res = filter_by_city("Москва")
+    assert len(res) == 3
+
+
+def test_filter_by_salary(sample_vacancies):
+    res = filter_by_salary(150000)
+    assert len(res) == 2
+
+
+class DummyMessage:
+    def __init__(self, text=""):
+        self.text = text
+        self.replies = []
+
+    def reply_text(self, text, **kwargs):
+        self.replies.append(text)
+
+
+def test_keyword_scenario(sample_vacancies):
+    user_states.clear()
+    msg = DummyMessage()
+    update_cb = type(
+        "U",
+        (),
+        {
+            "callback_query": type(
+                "CQ",
+                (),
+                {
+                    "data": "keyword",
+                    "message": type(
+                        "M",
+                        (),
+                        {"chat_id": 1, "reply_text": msg.reply_text},
+                    )(),
+                    "answer": lambda *a, **k: None,
+                },
+            )(),
+        },
+    )()
+
+    _on_filter_choice(update_cb, None)
+    assert user_states[1] == "keyword"
+
+    update_txt = type(
+        "U2",
+        (),
+        {
+            "message": DummyMessage("Python разработчик"),
+            "effective_chat": type("C", (), {"id": 1})(),
+        },
+    )()
+
+    _on_text(update_txt, None)
+    assert user_states.get(1) is None
+    # ответ содержит две ссылки на вакансии
+    assert update_txt.message.replies
+    assert update_txt.message.replies[0].count("http://") == 2
+


### PR DESCRIPTION
## Summary
- добавить поддержку telegram-бота версии 13
- реализовать inline-кнопки для выбора фильтра вакансий
- хранить состояния пользователей в `user_states`
- реализовать фильтры `filter_by_keywords`, `filter_by_city`, `filter_by_salary`
- покрыть тестами новые функции и сценарий выбора по ключевым словам

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686959f0ed50832d9f14345a4fb312ff